### PR TITLE
Create SSA packages for direct imports only

### DIFF
--- a/wastedassign.go
+++ b/wastedassign.go
@@ -34,20 +34,10 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	// Plundered from buildssa.Run.
 	prog := ssa.NewProgram(pass.Fset, ssa.NaiveForm)
 
-	// Create SSA packages for all imports.
-	// Order is not significant.
-	created := make(map[*types.Package]bool)
-	var createAll func(pkgs []*types.Package)
-	createAll = func(pkgs []*types.Package) {
-		for _, p := range pkgs {
-			if !created[p] {
-				created[p] = true
-				prog.CreatePackage(p, nil, nil, true)
-				createAll(p.Imports())
-			}
-		}
+	// Create SSA packages for direct imports.
+	for _, p := range pass.Pkg.Imports() {
+		prog.CreatePackage(p, nil, nil, true)
 	}
-	createAll(pass.Pkg.Imports())
 
 	// Create and build the primary package.
 	ssapkg := prog.CreatePackage(pass.Pkg, pass.Files, pass.TypesInfo, false)


### PR DESCRIPTION
Following up on #44 — restarting that work as focused, individually reviewable changes. This is the first.

The import-stub loop in `run` was copied from an early version of `buildssa.Run`, which recursively created an `ssa.Package` for every *transitive* import. Upstream `buildssa` narrowed this to direct imports only some years ago ([x/tools@v0.42.0](https://cs.opensource.google/go/x/tools/+/refs/tags/v0.42.0:go/analysis/passes/buildssa/buildssa.go)):

```go
// Create SSA packages for direct imports.
for _, p := range pass.Pkg.Imports() {
	prog.CreatePackage(p, nil, nil, true)
}
```

The transitive walk is redundant work. `prog.CreatePackage` enumerates every package-level member of each package it's handed, and the whole walk is redone from scratch for each analyzed package, making the cost `O(packages × transitive imports × members)` across a run. Only the direct imports are needed to satisfy the builder — dropping them entirely does panic (`Package("a").Build(): unsatisfied import: Program.CreatePackage("strings") was not called`), so this is the minimum that works.

### Impact

Analyzer time and allocation per pass, measured by running `wastedassign.Analyzer` directly over each corpus:

| corpus | transitive/direct imports | before | after | speedup |
|---|---|---|---|---|
| `golangci-lint ./pkg/...` (157 pkgs) | 45.9× | 3.90s / 3310MB | 0.21s / 225MB | **18.9×** / 14.7× |
| `std` (362 pkgs) | 7.5× | 5.85s / 6362MB | 3.22s / 4997MB | 1.82× / 1.27× |
| `go cmd/...` (235 pkgs) | 9.5× | 9.92s / 13599MB | 8.01s / 11910MB | 1.24× / 1.14× |

It's a strict reduction everywhere, since direct imports are a subset of transitive ones. The size of the win tracks how much of the dependency graph is transitive-only, which is why it's largest on application repos with real third-party dependency trees — i.e. where `golangci-lint` actually runs. Averaging 345 transitive imports against 7.5 direct ones per package is typical for a Go application.

End-to-end via golangci-lint's own instrumentation, linting its own repo with only `wastedassign` enabled:

```
before: wastedassign: 5.17252325s     Execution took 4.935299459s
after:  wastedassign: 423.377793ms    Execution took 1.86537975s
```

(That "after" also includes the two follow-up changes I'd like to propose separately.)

### Correctness

Diagnostics are byte-identical to `main` across three corpora — `std` (124 findings), `go cmd/...` (117), and `golangci-lint ./pkg/...` (0) — plus the existing `analysistest` suite passes.

### Follow-ups

If this looks reasonable I'd like to send two more, each standalone:

1. Replace the `rmInstrFromInstrs` filter with a slice expression — it rebuilds the instruction list once per instruction, which is `O(n²)` per block. Worth another 2.4× on top of this one on large packages.
2. Make the CFG walk allocation-free (reusable operand buffer and visit-count slice). ~2.3× less allocation.

I also tried the `opInLocals` → `map` change from #44 and it buys nothing measurable, so I've dropped it.
