### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version-file: go.mod
 
     - name: Test
       run: go test
@@ -27,7 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.62.2
-          args: '--disable-all --enable=goimports --enable=govet --exclude "printf: non-constant format string"'
+          version: v2.13.1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,10 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - govet
+
+formatters:
+  enable:
+    - goimports


### PR DESCRIPTION
CI has been failing on every pull request since #45 moved the go directive to 1.24.0 — see the Lint job on #46:

```
Error: can't load config: the Go language version (go1.23) used to build
golangci-lint is lower than the targeted Go version (1.24.0)
```

`golangci-lint-action@v6` pins v1.62.2, which is built with go1.23 and refuses to load a module targeting a newer Go. This moves to the v9 action and v2.13.1.

v2 dropped the `--disable-all` and `--exclude` flags, so the linter selection has to move into a config file. It's the same two linters as before:

```yaml
version: "2"

linters:
  default: none
  enable:
    - govet

formatters:
  enable:
    - goimports
```

The `printf: non-constant format string` exclusion is gone rather than translated — it was there for the `pass.Reportf(was.pos, was.reason)` call that #45 already fixed, and `golangci-lint run` is clean without it. I checked both linters still fire by feeding it a deliberately broken file:

```
sanity_check.go:4:1: File is not properly formatted (goimports)
sanity_check.go:8:41: printf: fmt.Printf format %d has arg "x" of wrong type string (govet)
```

I also set the Test job's Go version from `go.mod` rather than pinning 1.23, so the two jobs can't drift apart from the module again.

This is the CI half of #44 that never got split out — separate from the performance work in #46, and worth landing first since #46 can't go green until it does.
